### PR TITLE
Add Too PG and Too mature buttons to taste step

### DIFF
--- a/src/components/FindForm.tsx
+++ b/src/components/FindForm.tsx
@@ -1032,6 +1032,24 @@ export default function FindForm() {
                   >
                     <i className="fas fa-star text-xs" /> Highest rated
                   </button>
+                  <button
+                    onClick={() => refineTaste(contentType === 'movie'
+                      ? { 'certification.gte': 'R', certification_country: 'US' }
+                      : { 'certification.gte': 'TV-MA', certification_country: 'US' }
+                    )}
+                    className="flex items-center gap-1.5 px-4 py-2 rounded-full bg-gray-800 border border-gray-700 text-gray-300 text-sm font-semibold hover:bg-netflix-red hover:border-netflix-red hover:text-white transition-all"
+                  >
+                    <i className="fas fa-exclamation-circle text-xs" /> Too PG → R-rated
+                  </button>
+                  <button
+                    onClick={() => refineTaste(contentType === 'movie'
+                      ? { 'certification.lte': 'PG', certification_country: 'US' }
+                      : { 'certification.lte': 'TV-PG', certification_country: 'US' }
+                    )}
+                    className="flex items-center gap-1.5 px-4 py-2 rounded-full bg-gray-800 border border-gray-700 text-gray-300 text-sm font-semibold hover:bg-netflix-red hover:border-netflix-red hover:text-white transition-all"
+                  >
+                    <i className="fas fa-child text-xs" /> Too mature → Keep it PG
+                  </button>
                   {Object.keys(tasteFilters).length > 0 && (
                     <button
                       onClick={() => refineTaste({})}


### PR DESCRIPTION
Adds two cert-adjustment buttons to the taste step quick-adjust row:
- **Too PG → R-rated** — re-fetches pool with `certification.gte=R` (movies) or `TV-MA` (TV)
- **Too mature → Keep it PG** — re-fetches pool with `certification.lte=PG` (movies) or `TV-PG` (TV)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JChwEMwmpBj1gFiMVpV8cq)_